### PR TITLE
Add network policy

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,13 +18,11 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - config.openshift.io
+  - ""
   resources:
-  - clusterversions
+  - configmaps
   verbs:
-  - get
-  - list
-  - watch
+  - '*'
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - deployments
@@ -116,3 +124,9 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -20,3 +20,7 @@ package controllers
 // +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=services,verbs=get;create;watch;update;patch;list;delete
 // +kubebuilder:rbac:groups="core",resources=services,verbs=*
+
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=*
+
+// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=get;list;watch

--- a/controllers/kubebuilder_rbac.go
+++ b/controllers/kubebuilder_rbac.go
@@ -21,6 +21,6 @@ package controllers
 // +kubebuilder:rbac:groups="core",resources=services,verbs=get;create;watch;update;patch;list;delete
 // +kubebuilder:rbac:groups="core",resources=services,verbs=*
 
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=*
+// +kubebuilder:rbac:groups="core",resources=configmaps,verbs=*
 
-// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=*

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -32,11 +32,13 @@ import (
 	"github.com/meta-llama/llama-stack-k8s-operator/pkg/deploy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -81,6 +83,11 @@ func (r *LlamaStackDistributionReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, fmt.Errorf("failed to fetch LlamaStackDistribution: %w", err)
 	}
 
+	// Reconcile the NetworkPolicy
+	if err := r.reconcileNetworkPolicy(ctx, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile NetworkPolicy: %w", err)
+	}
+
 	// Reconcile the Deployment
 	if err := r.reconcileDeployment(ctx, instance); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile Deployment: %w", err)
@@ -108,6 +115,7 @@ func (r *LlamaStackDistributionReconciler) SetupWithManager(mgr ctrl.Manager) er
 		For(&llamav1alpha1.LlamaStackDistribution{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Complete(r)
 }
 
@@ -359,6 +367,97 @@ func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, ins
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 	return nil
+}
+
+// reconcileNetworkPolicy manages the NetworkPolicy for the LlamaStack server.
+func (r *LlamaStackDistributionReconciler) reconcileNetworkPolicy(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
+	// Use the container's port (defaulted to 8321 if unset)
+	port := instance.Spec.Server.ContainerSpec.Port
+	if port == 0 {
+		port = defaultPort
+	}
+
+	// get operator namespace
+	operatorNamespace, err := deploy.GetOperatorNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get operator namespace: %w", err)
+	}
+
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name + "-network-policy",
+			Namespace: instance.Namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					defaultLabelKey: defaultLabelValue,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app.kubernetes.io/part-of": defaultContainerName,
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{}, // Empty namespaceSelector to match all namespaces
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+							Port: &intstr.IntOrString{
+								IntVal: port,
+							},
+						},
+					},
+				},
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": operatorNamespace,
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+							Port: &intstr.IntOrString{
+								IntVal: port,
+							},
+						},
+					},
+				},
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+							Port: &intstr.IntOrString{
+								IntVal: port,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return deploy.ApplyNetworkPolicy(ctx, r.Client, r.Scheme, instance, networkPolicy, r.Log)
 }
 
 // NewLlamaStackDistributionReconciler creates a new reconciler with default image mappings.

--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -24,12 +24,15 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	llamav1alpha1 "github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
 	"github.com/meta-llama/llama-stack-k8s-operator/pkg/deploy"
+	"github.com/meta-llama/llama-stack-k8s-operator/pkg/featureflags"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -60,6 +63,8 @@ type LlamaStackDistributionReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Log    logr.Logger
+	// Feature flags
+	EnableNetworkPolicy bool
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -371,6 +376,18 @@ func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, ins
 
 // reconcileNetworkPolicy manages the NetworkPolicy for the LlamaStack server.
 func (r *LlamaStackDistributionReconciler) reconcileNetworkPolicy(ctx context.Context, instance *llamav1alpha1.LlamaStackDistribution) error {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name + "-network-policy",
+			Namespace: instance.Namespace,
+		},
+	}
+
+	// If feature is disabled, delete the NetworkPolicy if it exists
+	if !r.EnableNetworkPolicy {
+		return deploy.HandleDisabledNetworkPolicy(ctx, r.Client, networkPolicy, r.Log)
+	}
+
 	// Use the container's port (defaulted to 8321 if unset)
 	port := instance.Spec.Server.ContainerSpec.Port
 	if port == 0 {
@@ -383,73 +400,67 @@ func (r *LlamaStackDistributionReconciler) reconcileNetworkPolicy(ctx context.Co
 		return fmt.Errorf("failed to get operator namespace: %w", err)
 	}
 
-	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-network-policy",
-			Namespace: instance.Namespace,
+	networkPolicy.Spec = networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				defaultLabelKey: defaultLabelValue,
+			},
 		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					defaultLabelKey: defaultLabelValue,
-				},
-			},
-			PolicyTypes: []networkingv1.PolicyType{
-				networkingv1.PolicyTypeIngress,
-			},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{
-				{
-					From: []networkingv1.NetworkPolicyPeer{
-						{
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"app.kubernetes.io/part-of": defaultContainerName,
-								},
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeIngress,
+		},
+		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/part-of": defaultContainerName,
 							},
-							NamespaceSelector: &metav1.LabelSelector{}, // Empty namespaceSelector to match all namespaces
 						},
+						NamespaceSelector: &metav1.LabelSelector{}, // Empty namespaceSelector to match all namespaces
 					},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
-							Port: &intstr.IntOrString{
-								IntVal: port,
-							},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+						Port: &intstr.IntOrString{
+							IntVal: port,
 						},
 					},
 				},
-				{
-					From: []networkingv1.NetworkPolicyPeer{
-						{
-							PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"kubernetes.io/metadata.name": operatorNamespace,
-								},
+			},
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": operatorNamespace,
 							},
 						},
 					},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
-							Port: &intstr.IntOrString{
-								IntVal: port,
-							},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+						Port: &intstr.IntOrString{
+							IntVal: port,
 						},
 					},
 				},
-				{
-					From: []networkingv1.NetworkPolicyPeer{
-						{
-							PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
-						},
+			},
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{}, // Empty podSelector to match all pods
 					},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{
-							Protocol: (*corev1.Protocol)(ptr.To("TCP")),
-							Port: &intstr.IntOrString{
-								IntVal: port,
-							},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: (*corev1.Protocol)(ptr.To("TCP")),
+						Port: &intstr.IntOrString{
+							IntVal: port,
 						},
 					},
 				},
@@ -461,11 +472,57 @@ func (r *LlamaStackDistributionReconciler) reconcileNetworkPolicy(ctx context.Co
 }
 
 // NewLlamaStackDistributionReconciler creates a new reconciler with default image mappings.
-func NewLlamaStackDistributionReconciler(ctx context.Context, client client.Client, scheme *runtime.Scheme) *LlamaStackDistributionReconciler {
+func NewLlamaStackDistributionReconciler(ctx context.Context, client client.Client, scheme *runtime.Scheme) (*LlamaStackDistributionReconciler, error) {
 	log := log.FromContext(ctx).WithName("controller")
-	return &LlamaStackDistributionReconciler{
-		Client: client,
-		Scheme: scheme,
-		Log:    log,
+	// get operator namespace
+	operatorNamespace, err := deploy.GetOperatorNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator namespace: %w", err)
 	}
+
+	// Read the ConfigMap
+	configMap := &corev1.ConfigMap{}
+	configMapName := types.NamespacedName{
+		Name:      "llama-stack-operator-config",
+		Namespace: operatorNamespace,
+	}
+	err = client.Get(ctx, configMapName, configMap)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Create the ConfigMap if it doesn't exist
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName.Name,
+					Namespace: configMapName.Namespace,
+				},
+				Data: map[string]string{
+					featureflags.FeatureFlagsKey: fmt.Sprintf("%s: %v",
+						featureflags.EnableNetworkPolicyKey, featureflags.NetworkPolicyDefaultValue),
+				},
+			}
+			if err := client.Create(ctx, configMap); err != nil {
+				return nil, fmt.Errorf("failed to create ConfigMap: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to read ConfigMap: %w", err)
+		}
+	}
+
+	// Parse the feature flag
+	enableNetworkPolicy := featureflags.NetworkPolicyDefaultValue
+	if featureFlagsYAML, exists := configMap.Data[featureflags.FeatureFlagsKey]; exists {
+		var flags featureflags.FeatureFlags
+		if err := yaml.Unmarshal([]byte(featureFlagsYAML), &flags); err != nil {
+			log.Error(err, "failed to parse feature flags")
+		} else if flags.EnableNetworkPolicy != "" {
+			enableNetworkPolicy = strings.ToLower(flags.EnableNetworkPolicy) == "true"
+		}
+	}
+
+	return &LlamaStackDistributionReconciler{
+		Client:              client,
+		Scheme:              scheme,
+		Log:                 log,
+		EnableNetworkPolicy: enableNetworkPolicy,
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
+	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/controller-runtime v0.12.2
 )
 
@@ -76,9 +77,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
-	k8s.io/klog/v2 v2.60.1 // indirect
+	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -957,13 +957,15 @@ k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
-k8s.io/klog/v2 v2.60.1 h1:VW25q3bZx9uE3vvdL6M8ezOX79vA2Aq1nEWLqNQclHc=
 k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 h1:Gii5eqf+GmIEwGNKQYQClCayuJCe2/4fZUvF7VG99sU=
 k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42/go.mod h1:Z/45zLw8lUo4wdiUkI+v/ImEGAvu3WatcZl3lPMR4Rk=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e h1:KqK5c/ghOm8xkHYhlodbp6i6+r+ChV2vuAuVRdFbLro=
+k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/main.go
+++ b/main.go
@@ -105,7 +105,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (controllers.NewLlamaStackDistributionReconciler(ctx, cli, scheme)).SetupWithManager(mgr); err != nil {
+	reconciler, err := controllers.NewLlamaStackDistributionReconciler(ctx, cli, scheme)
+	if err != nil {
+		setupLog.Error(err, "failed to create reconciler")
+		os.Exit(1)
+	}
+	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LlamaStackDistribution")
 		os.Exit(1)
 	}

--- a/pkg/deploy/networkpolicy.go
+++ b/pkg/deploy/networkpolicy.go
@@ -1,0 +1,82 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	llamav1alpha1 "github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsOpenShift checks if the cluster is running OpenShift by looking for OpenShift-specific resources.
+func IsOpenShift(ctx context.Context, c client.Client) error {
+	// Try to get the OpenShift version from the cluster version
+	clusterVersion := &unstructured.Unstructured{}
+	clusterVersion.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterVersion",
+	})
+
+	err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion)
+	return err
+}
+
+// ApplyNetworkPolicy creates or updates a NetworkPolicy.
+func ApplyNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme,
+	instance *llamav1alpha1.LlamaStackDistribution, networkPolicy *networkingv1.NetworkPolicy, log logr.Logger) error {
+	// Only apply NetworkPolicy if running on OpenShift
+	if err := IsOpenShift(ctx, c); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Info("skipping NetworkPolicy creation - not running on OpenShift")
+			return nil
+		}
+		return fmt.Errorf("failed to check if running on OpenShift: %w", err)
+	}
+
+	// Set the controller reference
+	if err := ctrl.SetControllerReference(instance, networkPolicy, scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	// Check if the NetworkPolicy already exists
+	existing := &networkingv1.NetworkPolicy{}
+	err := c.Get(ctx, client.ObjectKeyFromObject(networkPolicy), existing)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Create the NetworkPolicy if it doesn't exist
+			if err := c.Create(ctx, networkPolicy); err != nil {
+				return fmt.Errorf("failed to create NetworkPolicy: %w", err)
+			}
+			log.Info("Created NetworkPolicy", "name", networkPolicy.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to get NetworkPolicy: %w", err)
+	}
+
+	// Update the NetworkPolicy if it exists
+	networkPolicy.ResourceVersion = existing.ResourceVersion
+	if err := c.Update(ctx, networkPolicy); err != nil {
+		return fmt.Errorf("failed to update NetworkPolicy: %w", err)
+	}
+	log.Info("Updated NetworkPolicy", "name", networkPolicy.Name)
+	return nil
+}
+
+func GetOperatorNamespace() (string, error) {
+	operatorNS, exist := os.LookupEnv("OPERATOR_NAMESPACE")
+	if exist && operatorNS != "" {
+		return operatorNS, nil
+	}
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	return string(data), err
+}

--- a/pkg/deploy/networkpolicy.go
+++ b/pkg/deploy/networkpolicy.go
@@ -9,40 +9,15 @@ import (
 	llamav1alpha1 "github.com/meta-llama/llama-stack-k8s-operator/api/v1alpha1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// IsOpenShift checks if the cluster is running OpenShift by looking for OpenShift-specific resources.
-func IsOpenShift(ctx context.Context, c client.Client) error {
-	// Try to get the OpenShift version from the cluster version
-	clusterVersion := &unstructured.Unstructured{}
-	clusterVersion.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "config.openshift.io",
-		Version: "v1",
-		Kind:    "ClusterVersion",
-	})
-
-	err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion)
-	return err
-}
-
 // ApplyNetworkPolicy creates or updates a NetworkPolicy.
 func ApplyNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme,
 	instance *llamav1alpha1.LlamaStackDistribution, networkPolicy *networkingv1.NetworkPolicy, log logr.Logger) error {
-	// Only apply NetworkPolicy if running on OpenShift
-	if err := IsOpenShift(ctx, c); err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Info("skipping NetworkPolicy creation - not running on OpenShift")
-			return nil
-		}
-		return fmt.Errorf("failed to check if running on OpenShift: %w", err)
-	}
-
 	// Set the controller reference
 	if err := ctrl.SetControllerReference(instance, networkPolicy, scheme); err != nil {
 		return fmt.Errorf("failed to set controller reference: %w", err)
@@ -69,6 +44,27 @@ func ApplyNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Sc
 		return fmt.Errorf("failed to update NetworkPolicy: %w", err)
 	}
 	log.Info("Updated NetworkPolicy", "name", networkPolicy.Name)
+	return nil
+}
+
+// HandleDisabledNetworkPolicy handles the deletion of a NetworkPolicy when the feature is disabled.
+// It checks if the NetworkPolicy exists and deletes it if found.
+func HandleDisabledNetworkPolicy(ctx context.Context, c client.Client, networkPolicy *networkingv1.NetworkPolicy, log logr.Logger) error {
+	log.Info("NetworkPolicy creation is disabled, checking if deletion is needed")
+	existingPolicy := &networkingv1.NetworkPolicy{}
+	err := c.Get(ctx, types.NamespacedName{Name: networkPolicy.Name, Namespace: networkPolicy.Namespace}, existingPolicy)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil // NetworkPolicy doesn't exist, nothing to do
+		}
+		return fmt.Errorf("failed to check NetworkPolicy existence: %w", err)
+	}
+
+	// NetworkPolicy exists, proceed with deletion
+	if err := c.Delete(ctx, networkPolicy); err != nil {
+		return fmt.Errorf("failed to delete NetworkPolicy: %w", err)
+	}
+	log.Info("Deleted NetworkPolicy", "name", networkPolicy.Name)
 	return nil
 }
 

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -1,0 +1,16 @@
+package featureflags
+
+// FeatureFlags represents the configuration for feature flags in the operator.
+type FeatureFlags struct {
+	// EnableNetworkPolicy controls whether NetworkPolicy resources should be created.
+	EnableNetworkPolicy string `yaml:"enableNetworkPolicy"`
+}
+
+const (
+	// FeatureFlagsKey is the key used in the ConfigMap to store feature flags.
+	FeatureFlagsKey = "featureFlags"
+	// EnableNetworkPolicyKey is the key for the network policy feature flag.
+	EnableNetworkPolicyKey = "enableNetworkPolicy"
+	// NetworkPolicyDefaultValue is the default value for the network policy feature flag.
+	NetworkPolicyDefaultValue = false
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Requires #13 to merge
## Description
This PR introduces automated creation of Network policy that has following ruleset for llama-stack server

- Pod Selection: The policy applies to pods with the label `app: llama-stack`
- Ingress Rules:
There are two ingress rules:
a) Allows traffic from:
          - Pods in the same namespace as the LlamaStack instance
          - Pods in the operator's namespace
          - Only allows TCP traffic on the configured port (defaults to 8321)
  
  b) Allows traffic from:
            - pods with the label `app.kubernetes.io/part-of: llama-stack`
            - Only allows TCP traffic on the configured port
- Egress Rules:
 - Allows all egress traffic



## How Has This Been Tested?
1. Deploy your inference server in a namespace. [Example](https://gist.github.com/VaishnaviHire/51b704a47784a33ea47945de172d8928)
2. Deploy operator
```
make deploy -e IMG=quay.io/opendatahub/llama-stack-k8s-operator:pr-14
```
3. Create CR. [Example](https://gist.github.com/VaishnaviHire/e962b5b4c9ce9ee455408ccc12222f9d)

## Expected Results
1. Ensure `<cr-name>--network-policy` is created in instance namespace.
2. llama-stack server is not accessible from pods that are missing the `app.kubernetes.io/part-of: llama-stack`.
3. All pods within the instance namespace can access the llama-stack server.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
