### PR TITLE
Add root context for the controller

### DIFF
--- a/controllers/llamastackdistribution_controller.go
+++ b/controllers/llamastackdistribution_controller.go
@@ -362,10 +362,11 @@ func (r *LlamaStackDistributionReconciler) updateStatus(ctx context.Context, ins
 }
 
 // NewLlamaStackDistributionReconciler creates a new reconciler with default image mappings.
-func NewLlamaStackDistributionReconciler(client client.Client, scheme *runtime.Scheme) *LlamaStackDistributionReconciler {
+func NewLlamaStackDistributionReconciler(ctx context.Context, client client.Client, scheme *runtime.Scheme) *LlamaStackDistributionReconciler {
+	log := log.FromContext(ctx).WithName("controller")
 	return &LlamaStackDistributionReconciler{
 		Client: client,
 		Scheme: scheme,
-		Log:    ctrl.Log.WithName("controller"),
+		Log:    log,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -62,6 +63,10 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	// root context
+	ctx := ctrl.SetupSignalHandler()
+	ctx = logf.IntoContext(ctx, setupLog)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -100,7 +105,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (controllers.NewLlamaStackDistributionReconciler(cli, scheme)).SetupWithManager(mgr); err != nil {
+	if err = (controllers.NewLlamaStackDistributionReconciler(ctx, cli, scheme)).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LlamaStackDistribution")
 		os.Exit(1)
 	}
@@ -117,7 +122,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit ensure we use single context across application. The changes ensure
- The context is properly propagated from the root of the application
- The logger is created with the same context that will be used in the Reconcile function
- We maintain consistency with how the controller-runtime handles context

Ref: https://go.dev/blog/context-and-structs 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
