### PR TITLE
fix: simplify distribution validation rule

### DIFF
--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -26,8 +26,7 @@ import (
 )
 
 // DistributionType defines the distribution configuration for llama-stack.
-// +kubebuilder:validation:XValidation:rule="(self.name == '' && self.image != '') || (self.name != '' && self.image == '')",message="Only one of name or image can be specified"
-// +kubebuilder:validation:XValidation:rule="self.name != '' || self.image != ''",message="Either name or image must be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.name) != has(self.image)",message="Only one of name or image can be specified"
 type DistributionType struct {
 	// Name is the distribution name that maps to supported distributions. Currently supported distributions are ollama and vllm.
 	// +optional


### PR DESCRIPTION
The previous validation rule for DistributionType was overly complex and required explicit empty values for unused fields. This change:

- Replaces the complex validation rule with a simpler `has()` check
- Ensures mutual exclusivity between name and image fields

The new validation rule `has(self.name) != has(self.image)` more clearly expresses the intent that only one of the fields should be present.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
