### PR TITLE
fixes XValidation rule for DistributionType struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testbin/*
 *~
 
 .golangci.mktmp.yml
+.envrc

--- a/api/v1alpha1/llamastackdistribution_types.go
+++ b/api/v1alpha1/llamastackdistribution_types.go
@@ -26,8 +26,8 @@ import (
 )
 
 // DistributionType defines the distribution configuration for llama-stack.
-// +kubebuilder:validation:XValidation:rule="(self.name == '' && self.image != '') || (self.name != '' && self.image == '')",message="Only one of name or image can be specified"
-// +kubebuilder:validation:XValidation:rule="self.name != '' || self.image != ''",message="Either name or image must be specified"
+// +kubebuilder:validation:XValidation:rule="!(has(self.name) && self.name != '' && has(self.image) && self.image != '')",message="Only one of name or image can be specified"
+// +kubebuilder:validation:XValidation:rule="has(self.name) && self.name != '' || has(self.image) && self.image != ''",message="Either name or image must be specified"
 type DistributionType struct {
 	// Name is the distribution name that maps to supported distributions. Currently supported distributions are ollama and vllm.
 	// +optional

--- a/config/crd/bases/llama.x-k8s.io_llamastackdistributions.yaml
+++ b/config/crd/bases/llama.x-k8s.io_llamastackdistributions.yaml
@@ -223,10 +223,11 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: Only one of name or image can be specified
-                      rule: (self.name == '' && self.image != '') || (self.name !=
-                        '' && self.image == '')
+                      rule: '!(has(self.name) && self.name != '''' && has(self.image)
+                        && self.image != '''')'
                     - message: Either name or image must be specified
-                      rule: self.name != '' || self.image != ''
+                      rule: has(self.name) && self.name != '' || has(self.image) &&
+                        self.image != ''
                   podOverrides:
                     description: PodOverrides allows advanced pod-level customization.
                     properties:


### PR DESCRIPTION
## Description
```
spec.server.distribution: Invalid value: "object": no such key: image evaluating rule: Only one of name or image can be specified
```
Above issue occurs because when a field like image is omitted from the CR YAML (because it’s omitempty and unset), the self.image reference does not exist, and trying to access it directly without a presence check causes the no such key error.

This PR has `has(self.name) and has(self.image)` to check if the field is present in the request, not just if it’s non-empty.

## How Has This Been Tested?
By running the below CR locally.
```
apiVersion: llama.x-k8s.io/v1alpha1
kind: LlamaStackDistribution
metadata:
  name: llamastackdistribution-sample
  namespace: test
spec:
  replicas: 1
  server:
    distribution:
      name: "ollama"
      #image: "llamastack/distribution-ollama:latest"
    containerSpec:
      port: 8321
      env:
      - name: INFERENCE_MODEL
        value: "meta-llama/Llama-3.2-3B-Instruct" 
      - name: OLLAMA_URL
        value: "http://ollama-server-service.default.svc.cluster.local:11434"
    podOverrides:
      volumes:
      - name: llama-storage
        emptyDir: {}
      volumeMounts:
      - name: llama-storage
        mountPath: "/root/.llama"
```

Closes: #32 

